### PR TITLE
[FIX-152] ChartConfiguration now implements Serializable

### DIFF
--- a/chartjs-wrapper/src/main/java/de/adesso/wickedcharts/chartjs/ChartConfiguration.java
+++ b/chartjs-wrapper/src/main/java/de/adesso/wickedcharts/chartjs/ChartConfiguration.java
@@ -6,6 +6,7 @@ import de.adesso.wickedcharts.chartjs.chartoptions.Data;
 import de.adesso.wickedcharts.chartjs.chartoptions.Options;
 import lombok.experimental.Accessors;
 
+import java.io.Serializable;
 import java.util.List;
 
 /**
@@ -13,7 +14,7 @@ import java.util.List;
  */
 @Accessors(chain = true)
 @lombok.Data
-public class ChartConfiguration {
+public class ChartConfiguration implements Serializable {
 	private ChartType type;
 	private Data data;
 	private Options options;

--- a/showcase/wicked-charts-showcase-wicket14/src/main/java/de/adesso/wickedcharts/showcase/configurations/base/ShowcaseConfiguration.java
+++ b/showcase/wicked-charts-showcase-wicket14/src/main/java/de/adesso/wickedcharts/showcase/configurations/base/ShowcaseConfiguration.java
@@ -15,7 +15,7 @@ import java.util.Scanner;
  * The base class for all chart configurations for the showcase
  */
 @SuppressWarnings("serial")
-public abstract class ShowcaseConfiguration extends ChartConfiguration implements Serializable {
+public abstract class ShowcaseConfiguration extends ChartConfiguration {
 
 	protected List<Integer> randomIntegerList(int size) {
 		List<Integer> dataList = new ArrayList<Integer>();

--- a/showcase/wicked-charts-showcase-wicket15/src/main/java/de/adesso/wickedcharts/showcase/configurations/base/ShowcaseConfiguration.java
+++ b/showcase/wicked-charts-showcase-wicket15/src/main/java/de/adesso/wickedcharts/showcase/configurations/base/ShowcaseConfiguration.java
@@ -15,10 +15,10 @@ import java.util.Scanner;
  * The base class for all chart configurations for the showcase
  */
 @SuppressWarnings("serial")
-public abstract class ShowcaseConfiguration extends ChartConfiguration implements Serializable {
+public abstract class ShowcaseConfiguration extends ChartConfiguration{
 
 	protected List<Integer> randomIntegerList(int size) {
-		List<Integer> dataList = new ArrayList<Integer>();
+		List<Integer> dataList = new ArrayList<>();
 		Random rng = new Random();
 		for (int i = 0; i < size; i++) {
 			dataList.add(rng.nextInt(60) + 1);

--- a/showcase/wicked-charts-showcase-wicket6/src/main/java/de/adesso/wickedcharts/showcase/configurations/base/ShowcaseConfiguration.java
+++ b/showcase/wicked-charts-showcase-wicket6/src/main/java/de/adesso/wickedcharts/showcase/configurations/base/ShowcaseConfiguration.java
@@ -16,7 +16,7 @@ import java.util.Scanner;
  * The base class for all chart configurations for the showcase
  */
 @SuppressWarnings("serial")
-public abstract class ShowcaseConfiguration extends ChartConfiguration implements Serializable {
+public abstract class ShowcaseConfiguration extends ChartConfiguration {
 
 	protected List<Integer> randomIntegerList(int size) {
 		List<Integer> dataList = new ArrayList<Integer>();

--- a/showcase/wicked-charts-showcase-wicket7/src/main/java/de/adesso/wickedcharts/showcase/configurations/base/ShowcaseConfiguration.java
+++ b/showcase/wicked-charts-showcase-wicket7/src/main/java/de/adesso/wickedcharts/showcase/configurations/base/ShowcaseConfiguration.java
@@ -15,10 +15,10 @@ import java.util.Scanner;
  * The base class for all chart configurations for the showcase
  */
 @SuppressWarnings("serial")
-public abstract class ShowcaseConfiguration extends ChartConfiguration implements Serializable {
+public abstract class ShowcaseConfiguration extends ChartConfiguration{
 
 	protected List<Integer> randomIntegerList(int size) {
-		List<Integer> dataList = new ArrayList<Integer>();
+		List<Integer> dataList = new ArrayList<>();
 		Random rng = new Random();
 		for (int i = 0; i < size; i++) {
 			dataList.add(rng.nextInt(60) + 1);

--- a/showcase/wicked-charts-showcase-wicket8/src/main/java/de/adesso/wickedcharts/showcase/configurations/base/ShowcaseConfiguration.java
+++ b/showcase/wicked-charts-showcase-wicket8/src/main/java/de/adesso/wickedcharts/showcase/configurations/base/ShowcaseConfiguration.java
@@ -15,10 +15,10 @@ import java.util.Scanner;
  * The base class for all chart configurations for the showcase
  */
 @SuppressWarnings("serial")
-public abstract class ShowcaseConfiguration extends ChartConfiguration implements Serializable {
+public abstract class ShowcaseConfiguration extends ChartConfiguration {
 
 	protected List<Integer> randomIntegerList(int size) {
-		List<Integer> dataList = new ArrayList<Integer>();
+		List<Integer> dataList = new ArrayList<>();
 		Random rng = new Random();
 		for (int i = 0; i < size; i++) {
 			dataList.add(rng.nextInt(60) + 1);


### PR DESCRIPTION
It is no longer necessary to extend the configuration class just to implement Serializable.
This closes issue #152 