### PR TITLE
Added minSize and maxSize to plot options

### DIFF
--- a/highcharts-wrapper/src/main/java/de/adesso/wickedcharts/highcharts/options/PlotOptions.java
+++ b/highcharts-wrapper/src/main/java/de/adesso/wickedcharts/highcharts/options/PlotOptions.java
@@ -140,6 +140,10 @@ public class PlotOptions implements Serializable {
 
     private Integer stemWidth;
 
+    private PixelOrPercent minSize;
+
+    private PixelOrPercent maxSize;
+
     public PixelOrPercent getNeckWidth() {
         return neckWidth;
     }
@@ -643,6 +647,24 @@ public class PlotOptions implements Serializable {
 
     public PlotOptions setWhiskerLength(Integer whiskerLength) {
         this.whiskerLength = whiskerLength;
+        return this;
+    }
+
+    public PixelOrPercent getMinSize() {
+        return minSize;
+    }
+
+    public PlotOptions setMinSize(PixelOrPercent minSize) {
+        this.minSize = minSize;
+        return this;
+    }
+
+    public PixelOrPercent getMaxSize() {
+        return maxSize;
+    }
+
+    public PlotOptions setMaxSize(PixelOrPercent maxSize) {
+        this.maxSize = maxSize;
         return this;
     }
 

--- a/highcharts-wrapper/src/main/java/de/adesso/wickedcharts/highcharts/options/PlotOptionsChoice.java
+++ b/highcharts-wrapper/src/main/java/de/adesso/wickedcharts/highcharts/options/PlotOptionsChoice.java
@@ -218,8 +218,9 @@ public class PlotOptionsChoice implements Serializable {
         return bubble;
     }
 
-    public void setBubble(PlotOptions bubble) {
+    public PlotOptionsChoice setBubble(PlotOptions bubble) {
         this.bubble = bubble;
+	    return this;
     }
 
     public PlotOptionsChoice setPlotOptions(PlotOptions plotOptions, SeriesType type) {


### PR DESCRIPTION
Adding minSize and maxSize properties to plot options as solution to https://github.com/adessoAG/wicked-charts/issues/79