### PR TITLE
Adjusted the compile level for older Wicket versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ repositories {
 }
 
 dependencies {
-  compile 'de.adesso.wicked-charts:wicked-charts-wicket8:3.1.0'
+  compile 'de.adesso.wicked-charts:wicked-charts-wicket8:3.2.0'
 }
 ```
 
@@ -54,7 +54,7 @@ Maven:
 <dependency>
   <groupId>de.adesso.wicked-charts</groupId>
   <artifactId>wicked-charts-wicket8</artifactId>
-  <version>3.1.0</version>
+  <version>3.2.0</version>
   <type>pom</type>
 </dependency>
 
@@ -69,7 +69,7 @@ repositories {
 }
 
 dependencies {
-  compile 'de.adesso.wicked-charts:wicked-charts-wicket7:3.1.0'
+  compile 'de.adesso.wicked-charts:wicked-charts-wicket7:3.2.0'
 }
 ```
 
@@ -78,7 +78,7 @@ Maven:
 <dependency>
   <groupId>de.adesso.wicked-charts</groupId>
   <artifactId>wicked-charts-wicket7</artifactId>
-  <version>3.1.0</version>
+  <version>3.2.0</version>
   <type>pom</type>
 </dependency>
 ```
@@ -92,7 +92,7 @@ repositories {
 }
 
 dependencies {
-  compile 'de.adesso.wicked-charts:wicked-charts-wicket6:3.1.0'
+  compile 'de.adesso.wicked-charts:wicked-charts-wicket6:3.2.0'
 }
 ```
 
@@ -101,7 +101,7 @@ Maven:
 <dependency>
   <groupId>de.adesso.wicked-charts</groupId>
   <artifactId>wicked-charts-wicket6</artifactId>
-  <version>3.1.0</version>
+  <version>3.2.0</version>
   <type>pom</type>
 </dependency>
 ```
@@ -115,7 +115,7 @@ repositories {
 }
 
 dependencies {
-  compile 'de.adesso.wicked-charts:wicked-charts-wicket15:3.1.0'
+  compile 'de.adesso.wicked-charts:wicked-charts-wicket15:3.2.0'
 }
 ```
 
@@ -124,7 +124,7 @@ Maven:
 <dependency>
   <groupId>de.adesso.wicked-charts</groupId>
   <artifactId>wicked-charts-wicket15</artifactId>
-  <version>3.1.0</version>
+  <version>3.2.0</version>
   <type>pom</type>
 </dependency>
 ```
@@ -138,7 +138,7 @@ repositories {
 }
 
 dependencies {
-  compile 'de.adesso.wicked-charts:wicked-charts-wicket14:3.1.0'
+  compile 'de.adesso.wicked-charts:wicked-charts-wicket14:3.2.0'
 }
 ```
 
@@ -147,7 +147,7 @@ Maven:
 <dependency>
   <groupId>de.adesso.wicked-charts</groupId>
   <artifactId>wicked-charts-wicket14</artifactId>
-  <version>3.1.0</version>
+  <version>3.2.0</version>
   <type>pom</type>
 </dependency>
 ```
@@ -161,7 +161,7 @@ repositories {
 }
 
 dependencies {
-  compile 'de.adesso.wicked-charts:wicked-charts-jsf21:3.1.0'
+  compile 'de.adesso.wicked-charts:wicked-charts-jsf21:3.2.0'
 }
 ```
 
@@ -170,7 +170,7 @@ Maven:
 <dependency>
   <groupId>de.adesso.wicked-charts</groupId>
   <artifactId>wicked-charts-jsf21</artifactId>
-  <version>3.1.0</version>
+  <version>3.2.0</version>
   <type>pom</type>
 </dependency>
 ```
@@ -186,8 +186,8 @@ repositories {
 }
 
 dependencies {
-  compile 'de.adesso.wicked-charts:chartjs-wrapper:3.1.0'
-  compile 'de.adesso.wicked-charts:highcharts-wrapper:3.1.0'
+  compile 'de.adesso.wicked-charts:chartjs-wrapper:3.2.0'
+  compile 'de.adesso.wicked-charts:highcharts-wrapper:3.2.0'
 }
 ```
 
@@ -197,14 +197,14 @@ Maven:
     <dependency>
       <groupId>de.adesso.wicked-charts</groupId>
       <artifactId>chartjs-wrapper</artifactId>
-      <version>3.1.0</version>
+      <version>3.2.0</version>
       <type>pom</type>
     </dependency>
     
     <dependency>
       <groupId>de.adesso.wicked-charts</groupId>
       <artifactId>highcharts-wrapper</artifactId>
-      <version>3.1.0</version>
+      <version>3.2.0</version>
       <type>pom</type>
     </dependency>
 </dependencies>
@@ -219,7 +219,7 @@ repositories {
 }
 
 dependencies {
-  compile 'de.adesso.wicked-charts:wicked-charts-wicket8:3.2.0-SNAPSHOT'
+  compile 'de.adesso.wicked-charts:wicked-charts-wicket8:3.3.0-SNAPSHOT'
 }
 ```
 
@@ -228,7 +228,7 @@ Maven:
 <dependency>
   <groupId>de.adesso.wicked-charts</groupId>
   <artifactId>wicked-charts-wicket8</artifactId>
-  <version>3.2.0-SNAPSHOT</version>
+  <version>3.3.0-SNAPSHOT</version>
   <type>pom</type>
 </dependency>
 ```

--- a/build.gradle
+++ b/build.gradle
@@ -35,7 +35,6 @@ subprojects {
 
     // run gradle with "-Dsnapshot=true" to automatically append "-SNAPSHOT" to the version
     version = '3.2.0' + (Boolean.valueOf(System.getProperty("snapshot")) ? "-SNAPSHOT" : "")
-    sourceCompatibility = 1.8
 
     ext {
         bintrayUser = System.getProperty("bintray.user")

--- a/showcase/wicked-charts-showcase-wicket8/gradle.properties
+++ b/showcase/wicked-charts-showcase-wicket8/gradle.properties
@@ -1,1 +1,1 @@
-wicket_version=8.3.0
+wicket_version=8.4.0

--- a/wicket/wicked-charts-wicket14/build.gradle
+++ b/wicket/wicked-charts-wicket14/build.gradle
@@ -3,3 +3,8 @@ dependencies {
 	compile project(':chartjs-wrapper')
 	compile 'org.apache.wicket:wicket:1.4.23'
 }
+
+compileJava {
+	sourceCompatibility = 1.6
+	targetCompatibility = 1.6
+}

--- a/wicket/wicked-charts-wicket15/build.gradle
+++ b/wicket/wicked-charts-wicket15/build.gradle
@@ -3,3 +3,8 @@ dependencies {
 	compile project(':chartjs-wrapper')
 	compile 'org.apache.wicket:wicket-core:1.5.17'
 }
+
+compileJava {
+	sourceCompatibility = 1.6
+	targetCompatibility = 1.6
+}

--- a/wicket/wicked-charts-wicket6/build.gradle
+++ b/wicket/wicked-charts-wicket6/build.gradle
@@ -1,5 +1,10 @@
 dependencies {
 	compile project(':highcharts-wrapper')
 	compile project(':chartjs-wrapper')
-	compile 'org.apache.wicket:wicket-core:6.29.0' 
+	compile 'org.apache.wicket:wicket-core:6.30.0'
+}
+
+compileJava {
+	sourceCompatibility = 1.6
+	targetCompatibility = 1.6
 }

--- a/wicket/wicked-charts-wicket7/build.gradle
+++ b/wicket/wicked-charts-wicket7/build.gradle
@@ -1,6 +1,10 @@
 dependencies {
 	compile project(':highcharts-wrapper')
 	compile project(':chartjs-wrapper')
-	compile 'org.apache.wicket:wicket-core:7.10.0'
+	compile 'org.apache.wicket:wicket-core:7.12.0'
 }
 
+compileJava {
+	sourceCompatibility = 1.7
+	targetCompatibility = 1.7
+}

--- a/wicket/wicked-charts-wicket8/build.gradle
+++ b/wicket/wicked-charts-wicket8/build.gradle
@@ -1,6 +1,10 @@
 dependencies {
 	compile project(':highcharts-wrapper')
 	compile project(':chartjs-wrapper')
-	compile 'org.apache.wicket:wicket-core:8.1.0'
+	compile 'org.apache.wicket:wicket-core:8.4.0'
 }
 
+compileJava {
+	sourceCompatibility = 1.8
+	targetCompatibility = 1.8
+}


### PR DESCRIPTION
I've set `sourceCompatibility` and `targetCompatibility` to `1.6` for the Wicket 1.4, 1.5 and 1.6 modules, 
`1.7` for Wicket 7 and `1.8` for Wicket 8.
I've also adjusted the README for a 3.2.0 release