### PR TITLE
Changed wrappers compile level

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,7 +228,7 @@ Maven:
 <dependency>
   <groupId>de.adesso.wicked-charts</groupId>
   <artifactId>wicked-charts-wicket8</artifactId>
-  <version>3.3.0-SNAPSHOT</version>
+  <version>3.2.1-SNAPSHOT</version>
   <type>pom</type>
 </dependency>
 ```

--- a/build.gradle
+++ b/build.gradle
@@ -34,7 +34,7 @@ subprojects {
     }
 
     // run gradle with "-Dsnapshot=true" to automatically append "-SNAPSHOT" to the version
-    version = '3.2.0' + (Boolean.valueOf(System.getProperty("snapshot")) ? "-SNAPSHOT" : "")
+    version = '3.2.1' + (Boolean.valueOf(System.getProperty("snapshot")) ? "-SNAPSHOT" : "")
 
     ext {
         bintrayUser = System.getProperty("bintray.user")

--- a/build.gradle
+++ b/build.gradle
@@ -34,7 +34,7 @@ subprojects {
     }
 
     // run gradle with "-Dsnapshot=true" to automatically append "-SNAPSHOT" to the version
-    version = '3.3.0' + (Boolean.valueOf(System.getProperty("snapshot")) ? "-SNAPSHOT" : "")
+    version = '3.2.0' + (Boolean.valueOf(System.getProperty("snapshot")) ? "-SNAPSHOT" : "")
 
     ext {
         bintrayUser = System.getProperty("bintray.user")

--- a/chartjs-wrapper/build.gradle
+++ b/chartjs-wrapper/build.gradle
@@ -4,4 +4,10 @@ dependencies {
 	compile 'com.fasterxml.jackson.core:jackson-annotations:2.8.1'
 	compile 'com.fasterxml.jackson.core:jackson-core:2.8.1'
 	compile 'com.fasterxml.jackson.core:jackson-databind:2.8.1'
+	compile group: 'org.threeten', name: 'threetenbp', version: '1.3.8'
+}
+
+compileJava {
+	sourceCompatibility = 1.6
+	targetCompatibility = 1.6
 }

--- a/chartjs-wrapper/src/main/java/de/adesso/wickedcharts/chartjs/chartoptions/label/ConstLabel.java
+++ b/chartjs-wrapper/src/main/java/de/adesso/wickedcharts/chartjs/chartoptions/label/ConstLabel.java
@@ -1,9 +1,9 @@
 package de.adesso.wickedcharts.chartjs.chartoptions.label;
 
 import java.io.Serializable;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import java.util.stream.Collectors;
 
 /**
  * Defines constant textlabels for the axes .
@@ -19,12 +19,19 @@ public class ConstLabel extends Label implements Serializable {
 	}
 	
 	public static List<ConstLabel> of(String... texts) {
-		return Arrays.stream(texts).map(textLabel -> new ConstLabel(textLabel)).collect(Collectors.toList());
+		List<ConstLabel> resultList = new ArrayList<ConstLabel>();
+		for(String text : texts){
+			resultList.add(new ConstLabel(text));
+		}
+		return resultList;
 	}
 	
 	public static List<ConstLabel> of(List<String> textList) {
-		return textList.stream().map(textLabel -> new ConstLabel(textLabel)).collect(Collectors.toList());
-	}
+		List<ConstLabel> resultList = new ArrayList<ConstLabel>();
+		for(String text : textList){
+			resultList.add(new ConstLabel(text));
+		}
+		return resultList;	}
 
 	public String getText() {
 		return text;

--- a/chartjs-wrapper/src/main/java/de/adesso/wickedcharts/chartjs/chartoptions/label/DateTimeLabel.java
+++ b/chartjs-wrapper/src/main/java/de/adesso/wickedcharts/chartjs/chartoptions/label/DateTimeLabel.java
@@ -1,10 +1,12 @@
 package de.adesso.wickedcharts.chartjs.chartoptions.label;
 
+import org.threeten.bp.LocalDateTime;
+
 import java.io.Serializable;
-import java.time.LocalDateTime;
+
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import java.util.stream.Collectors;
 
 /**
  * Defines datetime labels for the axes.
@@ -20,11 +22,18 @@ public class DateTimeLabel extends Label implements Serializable {
 	}
 	
 	public static List<TextLabel> of(String... texts) {
-		return Arrays.stream(texts).map(textLabel -> new TextLabel(textLabel)).collect(Collectors.toList());
-	}
+		List<TextLabel> resultList = new ArrayList<TextLabel>();
+		for(String text : texts){
+			resultList.add(new TextLabel(text));
+		}
+		return resultList;	}
 	
 	public static List<TextLabel> of(List<String> textList) {
-		return textList.stream().map(textLabel -> new TextLabel(textLabel)).collect(Collectors.toList());
+		List<TextLabel> resultList = new ArrayList<TextLabel>();
+		for(String text : textList){
+			resultList.add(new TextLabel(text));
+		}
+		return resultList;
 	}
 
 	public LocalDateTime getDate() {

--- a/chartjs-wrapper/src/main/java/de/adesso/wickedcharts/chartjs/chartoptions/label/TextLabel.java
+++ b/chartjs-wrapper/src/main/java/de/adesso/wickedcharts/chartjs/chartoptions/label/TextLabel.java
@@ -2,10 +2,7 @@ package de.adesso.wickedcharts.chartjs.chartoptions.label;
 
 import java.io.Serializable;
 import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
-import java.util.stream.Collectors;
 
 /**
  * Defines simple textlabels for the axes .
@@ -22,11 +19,19 @@ public class TextLabel extends Label implements Serializable {
 	}
 	
 	public static List<TextLabel> of(String... texts) {
-		return Arrays.stream(texts).map(TextLabel::new).collect(Collectors.toList());
+		List<TextLabel> resultList = new ArrayList<TextLabel>();
+		for(String text : texts){
+			resultList.add(new TextLabel(text));
+		}
+		return resultList;
 	}
 	
 	public static List<TextLabel> of(List<String> textList) {
-		return textList.stream().map(TextLabel::new).collect(Collectors.toList());
+		List<TextLabel> resultList = new ArrayList<TextLabel>();
+		for(String text : textList){
+			resultList.add(new TextLabel(text));
+		}
+		return resultList;
 	}
 
 	public String getText() {

--- a/chartjs-wrapper/src/main/java/de/adesso/wickedcharts/chartjs/chartoptions/valueType/ConstValue.java
+++ b/chartjs-wrapper/src/main/java/de/adesso/wickedcharts/chartjs/chartoptions/valueType/ConstValue.java
@@ -4,9 +4,8 @@ import lombok.EqualsAndHashCode;
 import lombok.experimental.Accessors;
 
 import java.io.Serializable;
-import java.util.Arrays;
+import java.util.ArrayList;
 import java.util.List;
-import java.util.stream.Collectors;
 
 /**
  * This class defines a constant ValueType using a final String.
@@ -26,10 +25,17 @@ public class ConstValue extends ValueType implements Serializable {
 	}
 
 	public static List<ConstValue> of(final List<String> constList) {
-		return constList.stream().map(string -> new ConstValue(string)).collect(Collectors.toList());
+		List<ConstValue> resultList = new ArrayList<ConstValue>();
+		for(String s : constList){
+			resultList.add(new ConstValue(s));
+		}
+		return resultList;
 	}
 	
 	public static List<ConstValue> of(final String...consts) {
-		return Arrays.stream(consts).map(string -> new ConstValue(string)).collect(Collectors.toList());
-	}
+		List<ConstValue> resultList = new ArrayList<ConstValue>();
+		for(String s : consts){
+			resultList.add(new ConstValue(s));
+		}
+		return resultList;		}
 }

--- a/chartjs-wrapper/src/main/java/de/adesso/wickedcharts/chartjs/chartoptions/valueType/DateTimeValue.java
+++ b/chartjs-wrapper/src/main/java/de/adesso/wickedcharts/chartjs/chartoptions/valueType/DateTimeValue.java
@@ -2,9 +2,9 @@ package de.adesso.wickedcharts.chartjs.chartoptions.valueType;
 
 import lombok.EqualsAndHashCode;
 import lombok.experimental.Accessors;
+import org.threeten.bp.LocalDateTime;
 
 import java.io.Serializable;
-import java.time.LocalDateTime;
 
 /**
  * This class defines a DateTimeValue object that can be used in charts that use different options related to time.

--- a/chartjs-wrapper/src/main/java/de/adesso/wickedcharts/chartjs/chartoptions/valueType/DoubleValue.java
+++ b/chartjs-wrapper/src/main/java/de/adesso/wickedcharts/chartjs/chartoptions/valueType/DoubleValue.java
@@ -4,9 +4,8 @@ import lombok.EqualsAndHashCode;
 import lombok.experimental.Accessors;
 
 import java.io.Serializable;
-import java.util.Arrays;
+import java.util.ArrayList;
 import java.util.List;
-import java.util.stream.Collectors;
 
 /**
  * This class wraps Doubles in a DoubleValue object.
@@ -39,10 +38,18 @@ public class DoubleValue extends ValueType implements Serializable {
 	}
 	
 	public static List<DoubleValue> of(List<Double> doubleList) {
-		return doubleList.stream().map(doubleVal -> new DoubleValue(doubleVal)).collect(Collectors.toList());
+		List<DoubleValue> resultList = new ArrayList<DoubleValue>();
+		for(Double i : doubleList){
+			resultList.add(new DoubleValue(i));
+		}
+		return resultList;
 	}
 	
 	public static List<DoubleValue> of(Double...doubles) {
-		return Arrays.stream(doubles).map(doubleVal -> new DoubleValue(doubleVal)).collect(Collectors.toList());
+		List<DoubleValue> resultList = new ArrayList<DoubleValue>();
+		for(Double i : doubles){
+			resultList.add(new DoubleValue(i));
+		}
+		return resultList;
 	}
 }

--- a/chartjs-wrapper/src/main/java/de/adesso/wickedcharts/chartjs/chartoptions/valueType/FloatValue.java
+++ b/chartjs-wrapper/src/main/java/de/adesso/wickedcharts/chartjs/chartoptions/valueType/FloatValue.java
@@ -4,9 +4,8 @@ import lombok.EqualsAndHashCode;
 import lombok.experimental.Accessors;
 
 import java.io.Serializable;
-import java.util.Arrays;
+import java.util.ArrayList;
 import java.util.List;
-import java.util.stream.Collectors;
 
 /**
  * This class wraps Floats in a FloatValue object.
@@ -38,10 +37,18 @@ public class FloatValue extends ValueType implements Serializable {
 	}
 
 	public static List<FloatValue> of(List<Float> floatList) {
-		return floatList.stream().map(floatVal -> new FloatValue(floatVal)).collect(Collectors.toList());
+		List<FloatValue> floatValues = new ArrayList<FloatValue>();
+		for(Float f : floatList){
+			floatValues.add(new FloatValue(f));
+		}
+		return floatValues;
 	}
 	
 	public static List<FloatValue> of(Float...floats) {
-		return Arrays.stream(floats).map(floatVal -> new FloatValue(floatVal)).collect(Collectors.toList());
+		List<FloatValue> floatValues = new ArrayList<FloatValue>();
+		for(Float f : floats){
+			floatValues.add(new FloatValue(f));
+		}
+		return floatValues;
 	}
 }

--- a/chartjs-wrapper/src/main/java/de/adesso/wickedcharts/chartjs/chartoptions/valueType/IntegerValue.java
+++ b/chartjs-wrapper/src/main/java/de/adesso/wickedcharts/chartjs/chartoptions/valueType/IntegerValue.java
@@ -4,9 +4,8 @@ import lombok.EqualsAndHashCode;
 import lombok.experimental.Accessors;
 
 import java.io.Serializable;
-import java.util.Arrays;
+import java.util.ArrayList;
 import java.util.List;
-import java.util.stream.Collectors;
 
 /**
  * This class wraps Integers in a IntegerValue object.
@@ -38,10 +37,18 @@ public class IntegerValue extends ValueType implements Serializable {
 	}
 
 	public static List<IntegerValue> of(List<Integer> integerList) {
-		return integerList.stream().map(integer -> new IntegerValue(integer)).collect(Collectors.toList());
+		List<IntegerValue> resultList = new ArrayList<IntegerValue>();
+		for(Integer i : integerList){
+			resultList.add(new IntegerValue(i));
+		}
+		return resultList;
 	}
 	
 	public static List<IntegerValue> of(Integer...integers) {
-		return Arrays.stream(integers).map(integer -> new IntegerValue(integer)).collect(Collectors.toList());
+		List<IntegerValue> resultList = new ArrayList<IntegerValue>();
+		for(Integer i : integers){
+			resultList.add(new IntegerValue(i));
+		}
+		return resultList;
 	}
 }

--- a/chartjs-wrapper/src/main/java/de/adesso/wickedcharts/chartjs/chartoptions/valueType/StringValue.java
+++ b/chartjs-wrapper/src/main/java/de/adesso/wickedcharts/chartjs/chartoptions/valueType/StringValue.java
@@ -5,9 +5,8 @@ import lombok.EqualsAndHashCode;
 import lombok.experimental.Accessors;
 
 import java.io.Serializable;
-import java.util.Arrays;
+import java.util.ArrayList;
 import java.util.List;
-import java.util.stream.Collectors;
 
 /**
  * This class wraps Strings in a StringValue object.
@@ -29,11 +28,19 @@ public class StringValue extends ValueType implements Serializable {
 	}
 
 	public static List<StringValue> of(List<String> stringList) {
-		return stringList.stream().map(StringValue::new).collect(Collectors.toList());
+		List<StringValue> resultList = new ArrayList<StringValue>();
+		for(String string : stringList){
+			resultList.add(new StringValue(string));
+		}
+		return resultList;
 	}
 	
 	public static List<StringValue> of(String...strings) {
-		return Arrays.stream(strings).map(StringValue::new).collect(Collectors.toList());
+		List<StringValue> resultList = new ArrayList<StringValue>();
+		for(String string : strings){
+			resultList.add(new StringValue(string));
+		}
+		return resultList;
 	}
 	
 }

--- a/chartjs-wrapper/src/main/java/de/adesso/wickedcharts/chartjs/jackson/serializer/DateTimeLabelSerializer.java
+++ b/chartjs-wrapper/src/main/java/de/adesso/wickedcharts/chartjs/jackson/serializer/DateTimeLabelSerializer.java
@@ -5,9 +5,9 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonSerializer;
 import com.fasterxml.jackson.databind.SerializerProvider;
 import de.adesso.wickedcharts.chartjs.chartoptions.label.DateTimeLabel;
+import org.threeten.bp.format.DateTimeFormatter;
 
 import java.io.IOException;
-import java.time.format.DateTimeFormatter;
 
 /**
  * Serializes a DateTimeLabel object to JSON
@@ -16,7 +16,7 @@ public class DateTimeLabelSerializer extends JsonSerializer<DateTimeLabel> {
 
 	private static final String MOMENT_FORMAT = "moment('%s',moment.ISO_8601)";
 	private static final DateTimeFormatter formatter = DateTimeFormatter.ISO_LOCAL_DATE_TIME;
-	
+
 	@Override
 	public void serialize(DateTimeLabel value, JsonGenerator gen, SerializerProvider serializers)
 			throws IOException, JsonProcessingException {

--- a/chartjs-wrapper/src/main/java/de/adesso/wickedcharts/chartjs/jackson/serializer/DateTimeValueSerializer.java
+++ b/chartjs-wrapper/src/main/java/de/adesso/wickedcharts/chartjs/jackson/serializer/DateTimeValueSerializer.java
@@ -5,9 +5,9 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonSerializer;
 import com.fasterxml.jackson.databind.SerializerProvider;
 import de.adesso.wickedcharts.chartjs.chartoptions.valueType.DateTimeValue;
+import org.threeten.bp.format.DateTimeFormatter;
 
 import java.io.IOException;
-import java.time.format.DateTimeFormatter;
 
 /**
  * Serializes a DateTimeValue object to JSON

--- a/chartjs-wrapper/src/test/java/de/adesso/wickedcharts/chartjs/jackson/serializer/LabelSerializerTest.java
+++ b/chartjs-wrapper/src/test/java/de/adesso/wickedcharts/chartjs/jackson/serializer/LabelSerializerTest.java
@@ -4,8 +4,7 @@ import de.adesso.wickedcharts.chartjs.chartoptions.label.*;
 import de.adesso.wickedcharts.chartjs.jackson.JsonRenderer;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-
-import java.time.LocalDateTime;
+import org.threeten.bp.LocalDateTime;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;

--- a/highcharts-wrapper/build.gradle
+++ b/highcharts-wrapper/build.gradle
@@ -5,3 +5,8 @@ dependencies {
 	compile 'com.fasterxml.jackson.core:jackson-core:2.8.1'
 	compile 'com.fasterxml.jackson.core:jackson-databind:2.8.1'
 }
+
+compileJava {
+	sourceCompatibility = 1.6
+	targetCompatibility = 1.6
+}

--- a/showcase/gradle.properties
+++ b/showcase/gradle.properties
@@ -1,4 +1,4 @@
 spring_boot_version=2.1.2.RELEASE
 spring_version=5.1.4.RELEASE
-wickedcharts_version=3.3.0
+wickedcharts_version=3.2.0-SNAPSHOT
 junit_version=5.4.0

--- a/showcase/gradle.properties
+++ b/showcase/gradle.properties
@@ -1,4 +1,4 @@
 spring_boot_version=2.1.2.RELEASE
 spring_version=5.1.4.RELEASE
-wickedcharts_version=3.3.0-SNAPSHOT
+wickedcharts_version=3.3.0
 junit_version=5.4.0

--- a/showcase/gradle.properties
+++ b/showcase/gradle.properties
@@ -1,4 +1,4 @@
 spring_boot_version=2.1.2.RELEASE
 spring_version=5.1.4.RELEASE
-wickedcharts_version=3.2.0-SNAPSHOT
+wickedcharts_version=3.2.1-SNAPSHOT
 junit_version=5.4.0

--- a/showcase/wicked-charts-showcase-options/src/main/java/de/adesso/wickedcharts/showcase/options/chartjs/TimeLineConfiguration.java
+++ b/showcase/wicked-charts-showcase-options/src/main/java/de/adesso/wickedcharts/showcase/options/chartjs/TimeLineConfiguration.java
@@ -8,9 +8,9 @@ import de.adesso.wickedcharts.chartjs.chartoptions.valueType.PointValue;
 import de.adesso.wickedcharts.chartjs.chartoptions.valueType.StringValue;
 import de.adesso.wickedcharts.chartjs.chartoptions.valueType.ValueType;
 import de.adesso.wickedcharts.showcase.options.chartjs.base.ShowcaseConfiguration;
+import org.threeten.bp.LocalDateTime;
+import org.threeten.bp.format.DateTimeFormatter;
 
-import java.time.LocalDateTime;
-import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;

--- a/showcase/wicked-charts-showcase-options/src/main/java/de/adesso/wickedcharts/showcase/options/chartjs/TimePointConfiguration.java
+++ b/showcase/wicked-charts-showcase-options/src/main/java/de/adesso/wickedcharts/showcase/options/chartjs/TimePointConfiguration.java
@@ -6,9 +6,9 @@ import de.adesso.wickedcharts.chartjs.chartoptions.colors.StringValueColor;
 import de.adesso.wickedcharts.chartjs.chartoptions.label.DateTimeLabel;
 import de.adesso.wickedcharts.chartjs.chartoptions.valueType.*;
 import de.adesso.wickedcharts.showcase.options.chartjs.base.ShowcaseConfiguration;
+import org.threeten.bp.LocalDateTime;
+import org.threeten.bp.format.DateTimeFormatter;
 
-import java.time.LocalDateTime;
-import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;

--- a/showcase/wicked-charts-showcase-options/src/main/java/de/adesso/wickedcharts/showcase/options/chartjs/TimeSeriesConfiguration.java
+++ b/showcase/wicked-charts-showcase-options/src/main/java/de/adesso/wickedcharts/showcase/options/chartjs/TimeSeriesConfiguration.java
@@ -4,9 +4,9 @@ import de.adesso.wickedcharts.chartjs.chartoptions.*;
 import de.adesso.wickedcharts.chartjs.chartoptions.label.DateTimeLabel;
 import de.adesso.wickedcharts.chartjs.chartoptions.valueType.DoubleValue;
 import de.adesso.wickedcharts.showcase.options.chartjs.base.ShowcaseConfiguration;
+import org.threeten.bp.LocalDateTime;
+import org.threeten.bp.temporal.ChronoUnit;
 
-import java.time.LocalDateTime;
-import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;


### PR DESCRIPTION
The chartjs wrapper had some Java 8 specific code. Most notably a few lambdas and `java.time` uses. 
To make the library compatible with old Java version, `java.time` has been replaced by `org.threeten.bp` which is direct backport inteted for use in exactly such use cases.