### PR TITLE
Change to last Jackson version that is  java6 compatible

### DIFF
--- a/chartjs-wrapper/build.gradle
+++ b/chartjs-wrapper/build.gradle
@@ -1,9 +1,9 @@
 dependencies {
 	compileOnly 'org.projectlombok:lombok:1.18.6'
 	annotationProcessor 'org.projectlombok:lombok:1.18.6'
-	compile 'com.fasterxml.jackson.core:jackson-annotations:2.8.1'
-	compile 'com.fasterxml.jackson.core:jackson-core:2.8.1'
-	compile 'com.fasterxml.jackson.core:jackson-databind:2.8.1'
+	compile 'com.fasterxml.jackson.core:jackson-annotations:2.7.9'
+	compile 'com.fasterxml.jackson.core:jackson-core:2.7.9'
+	compile 'com.fasterxml.jackson.core:jackson-databind:2.7.9'
 	compile group: 'org.threeten', name: 'threetenbp', version: '1.3.8'
 }
 

--- a/highcharts-wrapper/build.gradle
+++ b/highcharts-wrapper/build.gradle
@@ -1,9 +1,9 @@
 dependencies {
 	compileOnly 'org.projectlombok:lombok:1.18.6'
 	annotationProcessor 'org.projectlombok:lombok:1.18.6'
-	compile 'com.fasterxml.jackson.core:jackson-annotations:2.8.1'
-	compile 'com.fasterxml.jackson.core:jackson-core:2.8.1'
-	compile 'com.fasterxml.jackson.core:jackson-databind:2.8.1'
+	compile 'com.fasterxml.jackson.core:jackson-annotations:2.7.9'
+	compile 'com.fasterxml.jackson.core:jackson-core:2.7.9'
+	compile 'com.fasterxml.jackson.core:jackson-databind:2.7.9'
 }
 
 compileJava {

--- a/showcase/gradle.properties
+++ b/showcase/gradle.properties
@@ -1,4 +1,4 @@
 spring_boot_version=2.1.2.RELEASE
 spring_version=5.1.4.RELEASE
-wickedcharts_version=3.2.1
+wickedcharts_version=3.2.1-SNAPSHOT
 junit_version=5.4.0

--- a/showcase/gradle.properties
+++ b/showcase/gradle.properties
@@ -1,4 +1,4 @@
 spring_boot_version=2.1.2.RELEASE
 spring_version=5.1.4.RELEASE
-wickedcharts_version=3.2.1-SNAPSHOT
+wickedcharts_version=3.2.1
 junit_version=5.4.0


### PR DESCRIPTION
The wicket 1.4/1.5/6 modules will now work in (very) old java versions as well.