### PR TITLE
fix(DateTimeLabelFormatSerializer) quote issues

### DIFF
--- a/highcharts-wrapper/src/main/java/de/adesso/wickedcharts/highcharts/jackson/DateTimeLabelFormatSerializer.java
+++ b/highcharts-wrapper/src/main/java/de/adesso/wickedcharts/highcharts/jackson/DateTimeLabelFormatSerializer.java
@@ -34,7 +34,7 @@ public class DateTimeLabelFormatSerializer extends JsonSerializer<DateTimeLabelF
 		dateTimeFormatBuilder.append("{");
 
 		for (Entry<DateTimeProperties, String> property : value.getProperties().entrySet()) {
-			dateTimeFormatBuilder.append(" " + property.getKey().toCode() + ": '" + property.getValue() + "',");
+			dateTimeFormatBuilder.append("\"" + property.getKey().toCode() + "\": \"" + property.getValue() + "\",");
 		}
 
 		int lastCommaPosition = dateTimeFormatBuilder.lastIndexOf(",");

--- a/highcharts-wrapper/src/test/java/de/adesso/wickedcharts/highcharts/jackson/DateTimeLabelFormatTest.java
+++ b/highcharts-wrapper/src/test/java/de/adesso/wickedcharts/highcharts/jackson/DateTimeLabelFormatTest.java
@@ -38,7 +38,7 @@ public class DateTimeLabelFormatTest {
 		String json = renderer.toJson(dateTimeLabelFormat);
 
 		// then
-		assertEquals("{ second: '%e. %b' }", json);
+		assertEquals("{\"second\": \"%e. %b\" }", json);
 	}
 
 //	@Test
@@ -50,7 +50,7 @@ public class DateTimeLabelFormatTest {
 		dateTimeLabelFormat.setProperty(DateTimeProperties.HOUR, "%H:%M");
 		dateTimeLabelFormat.setProperty(DateTimeProperties.DAY, "%e. %b");
 		dateTimeLabelFormat.setProperty(DateTimeProperties.WEEK, "%e. %b");
-		dateTimeLabelFormat.setProperty(DateTimeProperties.MONTH, "%b \'%y");
+		dateTimeLabelFormat.setProperty(DateTimeProperties.MONTH, "%b '%y");
 		dateTimeLabelFormat.setProperty(DateTimeProperties.YEAR, "%Y");
 
 		JsonRenderer renderer = new JsonRenderer();
@@ -60,7 +60,7 @@ public class DateTimeLabelFormatTest {
 
 		// then
 		assertEquals(
-				"{ week: '%e. %b', hour: '%H:%M', minute: '%H:%M', year: '%Y', month: '%b \'%y', day: '%e. %b', second: '%H:%M:%S' }",
+				"{ \"week\": \"%e. %b\", \"hour\": \"%H:%M\", \"minute\": \"%H:%M\", \"year\": \"%Y\", \"month\": \"%b \'%y\", \"day\": \"%e. %b\", \"second\": \"%H:%M:%S\" }",
 				json);
 
 	}


### PR DESCRIPTION
Currently the serializer returns
```
"dateTimeLabelFormats" : { minute: '%H:%M:%S', day: '%H:%M:%S', week: '%H:%M:%S', year: '%H:%M:%S', second: '%H:%M:%S', hour: '%H:%M:%S' },
```
which is not not valid json (but ok as json5 though ;)